### PR TITLE
Driver restore

### DIFF
--- a/udi_interface/node.py
+++ b/udi_interface/node.py
@@ -58,11 +58,11 @@ class Node(object):
             for drv in db_drivers:
                 for d in self.drivers:
                     if d['driver'] == drv['driver']:
-                        NLOGGER.debug(f"Update default {d['driver']} to {drv['value']} / {drv['uom']}")
+                        NLOGGER.debug(f"Update {address} default {d['driver']} to {drv['value']} / {drv['uom']}")
                         d['value'] = drv['value']
                         d['uom'] = drv['uom']
         except Exception as e:
-            NLOGGER.error(f'Failed to update driver default values for {address}: {e}')
+            NLOGGER.error(f'Failed to update driver default values for node {address} of drv={drv}: {e}',exc_info=True)
                 
     def getDriver(self, driver):
         """
@@ -81,7 +81,7 @@ class Node(object):
 
         drv = next((item for (item,d) in enumerate(self.drivers) if d['driver'] == driver), None)
         if drv == None:
-            NLOGGER.error('setDriver: Invalid driver: {}'.format(driver))
+            NLOGGER.error('{}:{} Invalid driver: {}'.format(self.address,self.name,driver))
             return
 
         if uom != None and self.drivers[drv]['uom'] != uom:

--- a/udi_interface/node.py
+++ b/udi_interface/node.py
@@ -57,7 +57,7 @@ class Node(object):
         try:
             for drv in db_drivers:
                 for d in self.drivers:
-                    if d['driver'] == drv['driver']:
+                    if 'driver' in drv and d['driver'] == drv['driver']:
                         NLOGGER.debug(f"Update {address} default {d['driver']} to {drv['value']} / {drv['uom']}")
                         d['value'] = drv['value']
                         d['uom'] = drv['uom']

--- a/udi_interface/node.py
+++ b/udi_interface/node.py
@@ -55,7 +55,7 @@ class Node(object):
         Get the driver value
         """
         for dv in self.drivers:
-            NLOGGER.debug('{} - {} :: getting dv {}'.format(dv['driver'], dv['value'], driver))
+            NLOGGER.debug('{}:{} {} - {} :: getting dv {}'.format(self.address, self.name, dv['driver'], dv['value'], driver))
             if dv['driver'] == driver:
                 return dv['value']
 
@@ -79,10 +79,10 @@ class Node(object):
             changed = True
 
         if report and (changed or force):
-            NLOGGER.debug('Reporting set {} to {} to Polyglot'.format(driver, value))
+            NLOGGER.debug('{}:{} Reporting set {} to {} to Polyglot'.format(self.address, self.name, driver, value))
             self.reportDriver(driver, force)
         else:
-            NLOGGER.debug('No change in {}\'s value'.format(driver))
+            NLOGGER.debug('{}:{} No change in {}\'s value'.format(self.address, self.name, driver))
 
     def reportDriver(self, driver, force):
         """ Send existing driver value to ISY """

--- a/udi_interface/node.py
+++ b/udi_interface/node.py
@@ -57,7 +57,7 @@ class Node(object):
         try:
             for drv in db_drivers:
                 for d in self.drivers:
-                    if 'driver' in drv and d['driver'] == drv['driver']:
+                    if 'restore' in d and d['restore'] and 'driver' in drv and d['driver'] == drv['driver']:
                         NLOGGER.debug(f"Update {address} default {d['driver']} to {drv['value']} / {drv['uom']}")
                         d['value'] = drv['value']
                         d['uom'] = drv['uom']


### PR DESCRIPTION
Bob,

I think this is a better option, and creates less traffic!  By default it does not restore values to the previous ones stored in the database since typically on startup the node server will set values as appropriate.  But, when we have user settable values we want those restored.  To make this work you can now set the parameter on the driver:

```
        {'driver': 'GV7', 'value': 0, 'uom': 2,  'restore':True},
```

The only issue will be for nodeservers that currently rely on this, they will need to be updated.  Alternative is to assume True, but I'd rather not.

This is just a proposal, and I confirmed it works using my ELK NS.

- Jim